### PR TITLE
Various improvements

### DIFF
--- a/Pico/config/config.php
+++ b/Pico/config/config.php
@@ -2,16 +2,8 @@
 
 
 /*
- * BASIC
- */
-$config['site_title'] = '';              // Site title
-$config['base_url'] = '';                    // Override base URL (e.g. http://example.com)
-// $config['rewrite_url'] = null;               // A boolean indicating forced URL rewriting
-
-/*
  * THEME
  */
-// $config['theme'] = 'default';                // Set the theme (defaults to "default")
 // $config['twig_config'] = array(              // Twig settings
 //     'cache' => false,                        // To enable Twig caching change this to a path to a writable directory
 //     'autoescape' => false,                   // Auto-escape Twig vars
@@ -24,8 +16,6 @@ $config['base_url'] = '';                    // Override base URL (e.g. http://e
 // $config['date_format'] = '%D %T';            // Set the PHP date format as described here: http://php.net/manual/en/function.strftime.php
 // $config['pages_order_by'] = 'alpha';         // Order pages by "alpha" or "date"
 // $config['pages_order'] = 'asc';              // Order pages "asc" or "desc"
-$config['content_dir'] = 'content/';  // Content directory
-$config['content_ext'] = '.md';              // File extension of content files to serve
 
 /*
  * TIMEZONE

--- a/Pico/plugins/00-PicoNextcloud.php
+++ b/Pico/plugins/00-PicoNextcloud.php
@@ -69,6 +69,29 @@ final class PicoNextcloud extends AbstractPicoPlugin {
 
 
 	/**
+	 * Triggered after Pico has evaluated the request URL
+	 *
+	 * @see    Pico::getRequestUrl()
+	 * @param  string &$url part of the URL describing the requested contents
+	 * @return void
+	 */
+	public function onRequestUrl(&$url)
+	{
+		$pluginConfig = $this->getConfig('PicoNextcloud');
+		$ncSiteId = !empty($pluginConfig['site_id']) ? $pluginConfig['site_id'] : '';
+
+		$requestUri = \OC::$server->getRequest()->getRawPathInfo();
+		if ($requestUri && $ncSiteId) {
+			$baseRequestUri = '/apps/cms_pico/pico/' . $ncSiteId . '/';
+			$baseRequestUriLength = strlen($baseRequestUri);
+			if (substr($requestUri, 0, $baseRequestUriLength) === $baseRequestUri) {
+				$url = substr($requestUri, $baseRequestUriLength);
+			}
+		}
+	}
+
+
+	/**
 	 * purify all entries from meta.
 	 *
 	 * @param  string[] &$meta parsed meta data

--- a/Pico/plugins/00-PicoNextcloud.php
+++ b/Pico/plugins/00-PicoNextcloud.php
@@ -150,6 +150,6 @@ final class PicoNextcloud extends AbstractPicoPlugin {
 	 * @return void
 	 */
 	public function onPageRendering(Twig_Environment &$twig, array &$twigVariables, &$templateName) {
-		$twigVariables['theme_url'] = '/apps/cms_pico/Pico/themes/' . $this->getConfig('theme');
+		$twigVariables['theme_url'] = OC_App::getAppWebPath('cms_pico') . '/Pico/themes/' . $this->getConfig('theme');
 	}
 }

--- a/Pico/plugins/00-PicoNextcloud.php
+++ b/Pico/plugins/00-PicoNextcloud.php
@@ -31,7 +31,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-final class Nextcloud extends AbstractPicoPlugin {
+final class PicoNextcloud extends AbstractPicoPlugin {
 	/**
 	 * This plugin is enabled by default?
 	 *

--- a/Pico/plugins/00-PicoNextcloud.php
+++ b/Pico/plugins/00-PicoNextcloud.php
@@ -54,6 +54,22 @@ final class PicoNextcloud extends AbstractPicoPlugin {
 	/** @var HTMLPurifier */
 	private $htmlPurifier;
 
+
+	/**
+	 * We don't want anyone to disable this plugin.
+	 *
+	 * @param bool $enabled
+	 * @param bool $recursive
+	 * @param bool $auto
+	 */
+	public function setEnabled($enabled, $recursive = true, $auto = false) {
+		if (!$enabled) {
+			throw new RuntimeException('PicoNextcloud plugin must not be disabled');
+		}
+
+		parent::setEnabled($enabled, $recursive, $auto);
+	}
+
 	/**
 	 * Loading stuff.
 	 *
@@ -66,21 +82,6 @@ final class PicoNextcloud extends AbstractPicoPlugin {
 	public function onConfigLoaded(array &$config) {
 		$this->config = $config;
 		$this->htmlPurifier = new HTMLPurifier(HTMLPurifier_Config::createDefault());
-
-	}
-
-
-	/**
-	 * We don't want anyone to disable this plugin.
-	 *
-	 * @param bool $enabled
-	 * @param bool $recursive
-	 * @param bool $auto
-	 */
-	public function setEnabled($enabled, $recursive = true, $auto = false) {
-		if ($enabled === false) {
-			throw new RuntimeException('Nextcloud plugin cannot be disabled');
-		}
 	}
 
 

--- a/Pico/plugins/00-PicoNextcloud.php
+++ b/Pico/plugins/00-PicoNextcloud.php
@@ -32,22 +32,6 @@
  *
  */
 final class PicoNextcloud extends AbstractPicoPlugin {
-	/**
-	 * This plugin is enabled by default?
-	 *
-	 * @see AbstractPicoPlugin::$enabled
-	 * @var boolean
-	 */
-	protected $enabled = true;
-
-	/**
-	 * This plugin depends on ...
-	 *
-	 * @see AbstractPicoPlugin::$dependsOn
-	 * @var string[]
-	 */
-	protected $dependsOn = array();
-
 	/** @var array */
 	private $config;
 
@@ -80,7 +64,6 @@ final class PicoNextcloud extends AbstractPicoPlugin {
 	 * @return void
 	 */
 	public function onConfigLoaded(array &$config) {
-		$this->config = $config;
 		$this->htmlPurifier = new HTMLPurifier(HTMLPurifier_Config::createDefault());
 	}
 
@@ -116,6 +99,7 @@ final class PicoNextcloud extends AbstractPicoPlugin {
 		return $newMeta;
 	}
 
+
 	/**
 	 * Purify the content from the page.
 	 *
@@ -143,7 +127,6 @@ final class PicoNextcloud extends AbstractPicoPlugin {
 	 * @return void
 	 */
 	public function onPageRendering(Twig_Environment &$twig, array &$twigVariables, &$templateName) {
-		$twigVariables['theme_url'] = '/apps/cms_pico/Pico/themes/' . $this->config['theme'];
+		$twigVariables['theme_url'] = '/apps/cms_pico/Pico/themes/' . $this->getConfig('theme');
 	}
-
 }

--- a/lib/Service/PicoService.php
+++ b/lib/Service/PicoService.php
@@ -193,12 +193,12 @@ class PicoService {
 
 
 	/**
-	 * @param Pico $pico ][p
+	 * @param Pico $pico
 	 *
 	 * @return string
 	 */
 	private function getAbsolutePathFromPico(Pico $pico) {
-		return $pico->getConfig()['content_dir'] . $pico->getCurrentPage()['id'] . '.md';
+		return $pico->getRequestFile() ?: '';
 	}
 
 

--- a/lib/Service/PicoService.php
+++ b/lib/Service/PicoService.php
@@ -184,9 +184,13 @@ class PicoService {
 			[
 				'site_title'    => $website->getName(),
 				'base_url'      => \OC::$WEBROOT . '/index.php/apps/cms_pico/pico/' . $website->getSite(),
+				'rewrite_url'   => true,
 				'theme'         => $website->getTheme(),
 				'content_dir'   => 'content/',
 				'content_ext'   => '.md',
+				'PicoNextcloud' => [
+					'site_id' => $website->getSite()
+				]
 			]
 		);
 	}

--- a/lib/Service/PicoService.php
+++ b/lib/Service/PicoService.php
@@ -178,15 +178,15 @@ class PicoService {
 	 * @param Pico $pico
 	 * @param Website $website
 	 */
-	private function generateConfig(Pico &$pico, Website $website) {
+	private function generateConfig(Pico $pico, Website $website) {
 		$this->themesService->hasToBeAValidTheme($website->getTheme());
 		$pico->setConfig(
 			[
-				'content_dir' => 'content/',
-				'content_ext' => '.md',
-				'theme'       => $website->getTheme(),
-				'site_title'  => $website->getName(),
-				'base_url'    => \OC::$WEBROOT . '/index.php/apps/cms_pico/pico/' . $website->getSite()
+				'site_title'    => $website->getName(),
+				'base_url'      => \OC::$WEBROOT . '/index.php/apps/cms_pico/pico/' . $website->getSite(),
+				'theme'         => $website->getTheme(),
+				'content_dir'   => 'content/',
+				'content_ext'   => '.md',
 			]
 		);
 	}

--- a/lib/Service/PicoService.php
+++ b/lib/Service/PicoService.php
@@ -49,7 +49,7 @@ class PicoService {
 
 	const DIR_ASSETS = 'assets/';
 
-	const NC_PLUGIN = 'Nextcloud';
+	const NC_PLUGIN = 'PicoNextcloud';
 
 	private $userId;
 


### PR DESCRIPTION
Please refer to the individual commits for details about the changes. The commits are cherry-pick'able.

---

I was trying to make the use of `mod_proxy` obsolete, but for some reason it isn't working as expected... I'm not sure whether this is caused by `PATH_INFO` in general or by Nextcloud, but adding the following to `.htaccess` should work, but doesn't:

```htaccess
RewriteEngine On
RewriteRule ^sites/(.*)$ index.php/apps/cms_pico/pico/$1 [QSA,L]
```

Strangely `PATH_INFO` is passed to PHP, but Nextcloud just redirects the user to the login page (or the files app, depending on whether the user is already logged in or not). No idea what is happening there...

The idea is to detect the rewrite by evaluating `$_SERVER['REQUEST_URI']` in `PicoNextcloud::onRequestUrl()` and modifying Pico's `$config['base_url']` to point to `https://cloud.example.com/sites/my_site`, letting `Pico::getPageUrl()` return rewritten and super user-friendly URLs instead of these `index.php/apps/cms_pico/pico` URLs. No need for `mod_proxy` anymore :smiley:

I'll add this feature to this PR as soon as I figure out why the rewrite rule isn't working... Any ideas?

---

fyi: We're currently working on Pico 2.0, see picocms/Pico#334. There are many improvements the Nextcloud `cms_pico` app might benefit from (like `Pico::loadPlugin()`, the new `$config['theme_url']` variable, ...), not to mention the benefits for users (like YAML-based configs, cleaner URLs, a rewritten default theme, hidden pages, ...). I'll open a PR as soon as we release Pico 2.0.