### PR TITLE
allow proper 404 response

### DIFF
--- a/lib/Http/PicoPageResponse.php
+++ b/lib/Http/PicoPageResponse.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
 namespace OCA\CMSPico\Http;
 
 use OCA\CMSPico\Model\PicoPage;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\EmptyContentSecurityPolicy;
 use OCP\AppFramework\Http\Response;
 
@@ -44,9 +45,9 @@ class PicoPageResponse extends Response
 
 		$this->addHeader('Content-Disposition', 'inline; filename=""');
 		$this->setContentSecurityPolicy(new PicoContentSecurityPolicy());
-		if ($page->is404Content())
-		{
-			$this->setStatus(404);
+
+		if ($page->is404Content()) {
+			$this->setStatus(Http::STATUS_NOT_FOUND);
 		}
 	}
 

--- a/lib/Http/PicoPageResponse.php
+++ b/lib/Http/PicoPageResponse.php
@@ -44,6 +44,10 @@ class PicoPageResponse extends Response
 
 		$this->addHeader('Content-Disposition', 'inline; filename=""');
 		$this->setContentSecurityPolicy(new PicoContentSecurityPolicy());
+		if ($page->is404Content())
+		{
+			$this->setStatus(404);
+		}
 	}
 
 	/**

--- a/lib/Model/PicoPage.php
+++ b/lib/Model/PicoPage.php
@@ -125,4 +125,12 @@ class PicoPage
 	{
 		return $this->output;
 	}
+
+	/**
+	 * @return bool
+	 */
+	public function is404Content(): bool
+	{
+		return $this->pico->is404Content();
+	}
 }


### PR DESCRIPTION
Checks if the 404 page is being sent and updates the response status for proper indexing/logging of requests for nonexistent pages - fix for #90 