### PR TITLE
Adapt cacheFor to server changes

### DIFF
--- a/lib/Http/PicoAssetResponse.php
+++ b/lib/Http/PicoAssetResponse.php
@@ -74,9 +74,9 @@ class PicoAssetResponse extends DownloadResponse
 		$this->setLastModified($asset->getLastModified());
 
 		if ($enableCache && isset($this->cacheFor[$mimeType])) {
-			$this->cacheFor($this->cacheFor[$mimeType], $asset->isPublicAsset());
+			$this->picoCacheFor($this->cacheFor[$mimeType], $asset->isPublicAsset());
 		} else {
-			$this->cacheFor(0);
+			$this->picoCacheFor(0);
 		}
 	}
 
@@ -102,7 +102,7 @@ class PicoAssetResponse extends DownloadResponse
 	 *
 	 * @return $this
 	 */
-	public function cacheFor(int $cacheSeconds, bool $public = false, bool $immutable = false): self
+	private function picoCacheFor(int $cacheSeconds, bool $public = false, bool $immutable = false): self
 	{
 		if ($cacheSeconds > 0) {
 			$pragma = $public ? 'public' : 'private';


### PR DESCRIPTION
Instead of using the same name for the PicoAssetResponse cacheFor method
as the OCP Response class, use a custom name. This is less likely to break in
the future.

Signed-off-by: Carl Schwan <carl@carlschwan.eu>