### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -141,8 +141,8 @@
 				}
 
 				$.each($itemTemplate.data(), function (key, value) {
-					if (key.substr(0, 4) === 'item') {
-						key = key[4].toLowerCase() + key.substr(5);
+					if (key.slice(0, 4) === 'item') {
+						key = key[4].toLowerCase() + key.slice(5);
 						itemData[key] = value;
 					}
 				});

--- a/js/personal.js
+++ b/js/personal.js
@@ -91,7 +91,7 @@
 
 			this.$itemTemplate = $(options.itemTemplate);
 			this.$privateSettingsTemplate = $(options.privateSettingsTemplate);
-			this.websiteBaseUrl = options.websiteBaseUrl + ((options.websiteBaseUrl.substr(-1) !== '/') ? '/' : '');
+			this.websiteBaseUrl = options.websiteBaseUrl + ((options.websiteBaseUrl.slice(-1) !== '/') ? '/' : '');
 
 			var signature = 'OCA.CMSPico.WebsiteList.initialize()';
 			if (!this.$itemTemplate.length) {

--- a/js/pico.js
+++ b/js/pico.js
@@ -129,7 +129,7 @@
 		 */
 		_api: function (method, item, data, callback) {
 			var that = this,
-				url = this.route + (item ? ((this.route.substr(-1) !== '/') ? '/' : '') + item : '');
+				url = this.route + (item ? ((this.route.slice(-1) !== '/') ? '/' : '') + item : '');
 
 			this._content(this.$loadingTemplate);
 
@@ -355,8 +355,8 @@
 			var pos = eventName.indexOf('.');
 			pos = (pos !== -1) ? pos : eventName.length;
 
-			var type = eventName.substr(0, pos),
-				id = eventName.substr(pos + 1);
+			var type = eventName.slice(0, pos),
+				id = eventName.slice(pos + 1);
 
 			if (!type || !id) {
 				return false;
@@ -718,7 +718,7 @@
 					var result = dataObject[matches[1]],
 						subKey = matches[2];
 
-					key = key.substr(matches[0].length);
+					key = key.slice(matches[0].length);
 					matches = key.match(/^\[(\d*|[a-z0-9_]+)\]/i);
 
 					while (matches !== null) {
@@ -729,7 +729,7 @@
 						result = result[subKey];
 						subKey = matches[1];
 
-						key = key.substr(matches[0].length);
+						key = key.slice(matches[0].length);
 						matches = key.match(/^\[(\d*|[a-z0-9_]+)\]/i);
 					}
 


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.