### PR TITLE
fix: replace logger

### DIFF
--- a/lib/Controller/ControllerTrait.php
+++ b/lib/Controller/ControllerTrait.php
@@ -27,11 +27,11 @@ namespace OCA\CMSPico\Controller;
 use OCA\CMSPico\AppInfo\Application;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
-use OCP\ILogger;
+use Psr\Log\LoggerInterface;
 
 trait ControllerTrait
 {
-	/** @var ILogger */
+	/** @var LoggerInterface */
 	private $logger;
 
 	/**
@@ -42,7 +42,7 @@ trait ControllerTrait
 	 */
 	private function createErrorResponse(\Throwable $exception, array $data = []): DataResponse
 	{
-		$this->logger->logException($exception, [ 'app' => Application::APP_NAME, 'level' => 2 ]);
+		$this->logger->error($exception, [ 'app' => Application::APP_NAME, 'level' => 2 ]);
 
 		$data['status'] = 0;
 		if (\OC::$server->getSystemConfig()->getValue('debug', false)) {

--- a/lib/Controller/PluginsController.php
+++ b/lib/Controller/PluginsController.php
@@ -32,8 +32,8 @@ use OCA\CMSPico\Service\PluginsService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\IL10N;
-use OCP\ILogger;
 use OCP\IRequest;
+use Psr\Log\LoggerInterface;
 
 class PluginsController extends Controller
 {
@@ -48,12 +48,12 @@ class PluginsController extends Controller
 	/**
 	 * PluginsController constructor.
 	 *
-	 * @param IRequest       $request
-	 * @param IL10N          $l10n
-	 * @param ILogger        $logger
-	 * @param PluginsService $pluginsService
+	 * @param IRequest        $request
+	 * @param IL10N           $l10n
+	 * @param LoggerInterface $logger
+	 * @param PluginsService  $pluginsService
 	 */
-	public function __construct(IRequest $request, IL10N $l10n, ILogger $logger, PluginsService $pluginsService)
+	public function __construct(IRequest $request, IL10N $l10n, LoggerInterface $logger, PluginsService $pluginsService)
 	{
 		parent::__construct(Application::APP_NAME, $request);
 

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -29,8 +29,8 @@ use OCA\CMSPico\AppInfo\Application;
 use OCA\CMSPico\Service\WebsitesService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\DataResponse;
-use OCP\ILogger;
 use OCP\IRequest;
+use Psr\Log\LoggerInterface;
 
 class SettingsController extends Controller
 {
@@ -43,10 +43,10 @@ class SettingsController extends Controller
 	 * SettingsController constructor.
 	 *
 	 * @param IRequest         $request
-	 * @param ILogger          $logger
+	 * @param LoggerInterface  $logger
 	 * @param WebsitesService  $websitesService
 	 */
-	public function __construct(IRequest $request, ILogger $logger, WebsitesService $websitesService)
+	public function __construct(IRequest $request, LoggerInterface $logger, WebsitesService $websitesService)
 	{
 		parent::__construct(Application::APP_NAME, $request);
 

--- a/lib/Controller/TemplatesController.php
+++ b/lib/Controller/TemplatesController.php
@@ -32,8 +32,8 @@ use OCA\CMSPico\Service\TemplatesService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\IL10N;
-use OCP\ILogger;
 use OCP\IRequest;
+use Psr\Log\LoggerInterface;
 
 class TemplatesController extends Controller
 {
@@ -50,10 +50,10 @@ class TemplatesController extends Controller
 	 *
 	 * @param IRequest         $request
 	 * @param IL10N            $l10n
-	 * @param ILogger          $logger
+	 * @param LoggerInterface  $logger
 	 * @param TemplatesService $templatesService
 	 */
-	public function __construct(IRequest $request, IL10N $l10n, ILogger $logger, TemplatesService $templatesService)
+	public function __construct(IRequest $request, IL10N $l10n, LoggerInterface $logger, TemplatesService $templatesService)
 	{
 		parent::__construct(Application::APP_NAME, $request);
 

--- a/lib/Controller/ThemesController.php
+++ b/lib/Controller/ThemesController.php
@@ -32,8 +32,8 @@ use OCA\CMSPico\Service\ThemesService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\IL10N;
-use OCP\ILogger;
 use OCP\IRequest;
+use Psr\Log\LoggerInterface;
 
 class ThemesController extends Controller
 {
@@ -48,12 +48,12 @@ class ThemesController extends Controller
 	/**
 	 * ThemesController constructor.
 	 *
-	 * @param IRequest      $request
-	 * @param IL10N         $l10n
-	 * @param ILogger       $logger
-	 * @param ThemesService $themesService
+	 * @param IRequest        $request
+	 * @param IL10N           $l10n
+	 * @param LoggerInterface $logger
+	 * @param ThemesService   $themesService
 	 */
-	public function __construct(IRequest $request, IL10N $l10n, ILogger $logger, ThemesService $themesService)
+	public function __construct(IRequest $request, IL10N $l10n, LoggerInterface $logger, ThemesService $themesService)
 	{
 		parent::__construct(Application::APP_NAME, $request);
 

--- a/lib/Controller/WebsitesController.php
+++ b/lib/Controller/WebsitesController.php
@@ -40,9 +40,9 @@ use OCA\CMSPico\Service\WebsitesService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\IL10N;
-use OCP\ILogger;
 use OCP\IRequest;
 use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
 use function OCA\CMSPico\t;
 
 class WebsitesController extends Controller
@@ -64,14 +64,14 @@ class WebsitesController extends Controller
 	 * @param IRequest        $request
 	 * @param IUserSession    $userSession
 	 * @param IL10N           $l10n
-	 * @param ILogger         $logger
+	 * @param LoggerInterface $logger
 	 * @param WebsitesService $websitesService
 	 */
 	public function __construct(
 		IRequest $request,
 		IUserSession $userSession,
 		IL10N $l10n,
-		ILogger $logger,
+		LoggerInterface $logger,
 		WebsitesService $websitesService
 	) {
 		parent::__construct(Application::APP_NAME, $request);

--- a/lib/Migration/AppDataRepairStep.php
+++ b/lib/Migration/AppDataRepairStep.php
@@ -34,9 +34,9 @@ use OCA\CMSPico\Service\ThemesService;
 use OCA\CMSPico\Service\WebsitesService;
 use OCP\Files\NotFoundException;
 use OCP\IGroupManager;
-use OCP\ILogger;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
+use Psr\Log\LoggerInterface;
 
 class AppDataRepairStep implements IRepairStep
 {
@@ -72,7 +72,7 @@ class AppDataRepairStep implements IRepairStep
 	/**
 	 * AppDataRepairStep constructor.
 	 *
-	 * @param ILogger          $logger
+	 * @param LoggerInterface  $logger
 	 * @param IGroupManager    $groupManager
 	 * @param WebsitesService  $websitesService
 	 * @param ConfigService    $configService
@@ -83,7 +83,7 @@ class AppDataRepairStep implements IRepairStep
 	 * @param MiscService      $miscService
 	 */
 	public function __construct(
-		ILogger $logger,
+		LoggerInterface $logger,
 		IGroupManager $groupManager,
 		WebsitesService $websitesService,
 		ConfigService $configService,

--- a/lib/Migration/MigrationTrait.php
+++ b/lib/Migration/MigrationTrait.php
@@ -25,21 +25,21 @@ declare(strict_types=1);
 namespace OCA\CMSPico\Migration;
 
 use OCA\CMSPico\AppInfo\Application;
-use OCP\ILogger;
 use OCP\Migration\IOutput;
+use Psr\Log\LoggerInterface;
 
 trait MigrationTrait
 {
-	/** @var ILogger */
+	/** @var LoggerInterface */
 	private $logger;
 
 	/** @var IOutput */
 	private $output;
 
 	/**
-	 * @param ILogger $logger
+	 * @param LoggerInterface $logger
 	 */
-	protected function setLogger(ILogger $logger): void
+	protected function setLogger(LoggerInterface $logger): void
 	{
 		$this->logger = $logger;
 	}
@@ -63,7 +63,7 @@ trait MigrationTrait
 		}
 
 		$message = sprintf($message, ...$arguments);
-		$this->logger->log(ILogger::INFO, $message, [ 'app' => Application::APP_NAME ]);
+		$this->logger->info($message, [ 'app' => Application::APP_NAME ]);
 		$this->output->info($message);
 	}
 
@@ -78,7 +78,7 @@ trait MigrationTrait
 		}
 
 		$message = sprintf($message, ...$arguments);
-		$this->logger->log(ILogger::WARN, $message, [ 'app' => Application::APP_NAME ]);
+		$this->logger->warning($message, [ 'app' => Application::APP_NAME ]);
 		$this->output->warning($message);
 	}
 

--- a/lib/Migration/Version010000From000908.php
+++ b/lib/Migration/Version010000From000908.php
@@ -37,6 +37,8 @@ use OCA\CMSPico\Service\ThemesService;
 use OCP\IDBConnection;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
+use OCP\Server;
+use Psr\Log\LoggerInterface;
 
 class Version010000From000908 extends SimpleMigrationStep
 {
@@ -62,7 +64,7 @@ class Version010000From000908 extends SimpleMigrationStep
 	 */
 	public function __construct()
 	{
-		$this->setLogger(\OC::$server->getLogger());
+		$this->setLogger(Server::get(LoggerInterface::class));
 
 		$this->databaseConnection = \OC::$server->getDatabaseConnection();
 		$this->configService = \OC::$server->query(ConfigService::class);

--- a/lib/Service/PicoService.php
+++ b/lib/Service/PicoService.php
@@ -42,7 +42,7 @@ use OCA\CMSPico\Pico;
 use OCP\Files\InvalidPathException;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
-use OCP\ILogger;
+use Psr\Log\LoggerInterface;
 
 class PicoService
 {
@@ -67,7 +67,7 @@ class PicoService
 	/** @var string */
 	public const CONTENT_EXT = '.md';
 
-	/** @var ILogger */
+	/** @var LoggerInterface */
 	private $logger;
 
 	/** @var AssetsService */
@@ -88,15 +88,15 @@ class PicoService
 	/**
 	 * PicoService constructor.
 	 *
-	 * @param ILogger        $logger
-	 * @param AssetsService  $assetsService
-	 * @param ThemesService  $themesService
-	 * @param PluginsService $pluginsService
-	 * @param FileService    $fileService
-	 * @param MiscService    $miscService
+	 * @param LoggerInterface $logger
+	 * @param AssetsService   $assetsService
+	 * @param ThemesService   $themesService
+	 * @param PluginsService  $pluginsService
+	 * @param FileService     $fileService
+	 * @param MiscService     $miscService
 	 */
 	public function __construct(
-		ILogger $logger,
+		LoggerInterface $logger,
 		AssetsService $assetsService,
 		ThemesService $themesService,
 		PluginsService $pluginsService,
@@ -153,7 +153,7 @@ class PicoService
 				throw $e;
 			} catch (\Exception $e) {
 				$exception = new PicoRuntimeException($e);
-				$this->logger->logException($exception, [ 'app' => Application::APP_NAME ]);
+				$this->logger->error($exception, [ 'app' => Application::APP_NAME ]);
 				throw $exception;
 			}
 


### PR DESCRIPTION
The previous logger approach was removed at Nextcloud 30 and was needed to be replaced by Psr\Log\LoggerInterface

This PR fix:

```
Error: Call to undefined method OC\Server::getLogger() in /var/www/html/apps-writable/cms_pico/lib/Migration/Version010000From000908.php:65
```